### PR TITLE
회원가입 요청 과정 구현

### DIFF
--- a/Vitamin/Vitamin.xcodeproj/project.pbxproj
+++ b/Vitamin/Vitamin.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		4DC0316826A42DDD00E929A4 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 4DC0316726A42DDD00E929A4 /* .swiftlint.yml */; };
 		D8D75DD365F598B2B294FEDA /* Pods_Vitamin_VitaminUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7471B47FDDF0403AE1956667 /* Pods_Vitamin_VitaminUITests.framework */; };
 		D9A564DF26BCCE3800ACB0EB /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A564DE26BCCE3800ACB0EB /* NetworkManager.swift */; };
+		D9A564E226BCCF2100ACB0EB /* SignUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A564E126BCCF2100ACB0EB /* SignUp.swift */; };
 		D9C49EF8269A97E600A5FFA5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C49EF7269A97E600A5FFA5 /* AppDelegate.swift */; };
 		D9C49EFA269A97E600A5FFA5 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C49EF9269A97E600A5FFA5 /* SceneDelegate.swift */; };
 		D9C49EFC269A97E600A5FFA5 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C49EFB269A97E600A5FFA5 /* ViewController.swift */; };
@@ -51,6 +52,7 @@
 		79104825172E7C028AD3CDEA /* Pods_Vitamin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Vitamin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C69DADE05C6ABDC668F8EF3B /* Pods-Vitamin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Vitamin.release.xcconfig"; path = "Target Support Files/Pods-Vitamin/Pods-Vitamin.release.xcconfig"; sourceTree = "<group>"; };
 		D9A564DE26BCCE3800ACB0EB /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
+		D9A564E126BCCF2100ACB0EB /* SignUp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUp.swift; sourceTree = "<group>"; };
 		D9C49EF4269A97E600A5FFA5 /* Vitamin.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Vitamin.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9C49EF7269A97E600A5FFA5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D9C49EF9269A97E600A5FFA5 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -116,6 +118,7 @@
 		4DC030B9269AF75E00E929A4 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				D9A564E026BCCF1500ACB0EB /* Models */,
 				D9A564DD26BCCE2900ACB0EB /* WebService */,
 				4DC030B8269AF71500E929A4 /* UIViewControllers */,
 			);
@@ -159,6 +162,14 @@
 				D9A564DE26BCCE3800ACB0EB /* NetworkManager.swift */,
 			);
 			path = WebService;
+			sourceTree = "<group>";
+		};
+		D9A564E026BCCF1500ACB0EB /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				D9A564E126BCCF2100ACB0EB /* SignUp.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 		D9C49EEB269A97E600A5FFA5 = {
@@ -475,6 +486,7 @@
 				D9C49EFC269A97E600A5FFA5 /* ViewController.swift in Sources */,
 				D9C49EF8269A97E600A5FFA5 /* AppDelegate.swift in Sources */,
 				D9C49EFA269A97E600A5FFA5 /* SceneDelegate.swift in Sources */,
+				D9A564E226BCCF2100ACB0EB /* SignUp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Vitamin/Vitamin.xcodeproj/project.pbxproj
+++ b/Vitamin/Vitamin.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		D8D75DD365F598B2B294FEDA /* Pods_Vitamin_VitaminUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7471B47FDDF0403AE1956667 /* Pods_Vitamin_VitaminUITests.framework */; };
 		D9A564DF26BCCE3800ACB0EB /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A564DE26BCCE3800ACB0EB /* NetworkManager.swift */; };
 		D9A564E226BCCF2100ACB0EB /* SignUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A564E126BCCF2100ACB0EB /* SignUp.swift */; };
+		D9A564E426BD647100ACB0EB /* URLMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A564E326BD647100ACB0EB /* URLMaker.swift */; };
+		D9A564E626BD696900ACB0EB /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A564E526BD696900ACB0EB /* User.swift */; };
 		D9C49EF8269A97E600A5FFA5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C49EF7269A97E600A5FFA5 /* AppDelegate.swift */; };
 		D9C49EFA269A97E600A5FFA5 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C49EF9269A97E600A5FFA5 /* SceneDelegate.swift */; };
 		D9C49EFC269A97E600A5FFA5 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C49EFB269A97E600A5FFA5 /* ViewController.swift */; };
@@ -53,6 +55,8 @@
 		C69DADE05C6ABDC668F8EF3B /* Pods-Vitamin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Vitamin.release.xcconfig"; path = "Target Support Files/Pods-Vitamin/Pods-Vitamin.release.xcconfig"; sourceTree = "<group>"; };
 		D9A564DE26BCCE3800ACB0EB /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		D9A564E126BCCF2100ACB0EB /* SignUp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUp.swift; sourceTree = "<group>"; };
+		D9A564E326BD647100ACB0EB /* URLMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLMaker.swift; sourceTree = "<group>"; };
+		D9A564E526BD696900ACB0EB /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		D9C49EF4269A97E600A5FFA5 /* Vitamin.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Vitamin.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9C49EF7269A97E600A5FFA5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D9C49EF9269A97E600A5FFA5 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -160,6 +164,7 @@
 			isa = PBXGroup;
 			children = (
 				D9A564DE26BCCE3800ACB0EB /* NetworkManager.swift */,
+				D9A564E326BD647100ACB0EB /* URLMaker.swift */,
 			);
 			path = WebService;
 			sourceTree = "<group>";
@@ -168,6 +173,7 @@
 			isa = PBXGroup;
 			children = (
 				D9A564E126BCCF2100ACB0EB /* SignUp.swift */,
+				D9A564E526BD696900ACB0EB /* User.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -482,11 +488,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9A564E426BD647100ACB0EB /* URLMaker.swift in Sources */,
 				D9A564DF26BCCE3800ACB0EB /* NetworkManager.swift in Sources */,
 				D9C49EFC269A97E600A5FFA5 /* ViewController.swift in Sources */,
 				D9C49EF8269A97E600A5FFA5 /* AppDelegate.swift in Sources */,
 				D9C49EFA269A97E600A5FFA5 /* SceneDelegate.swift in Sources */,
 				D9A564E226BCCF2100ACB0EB /* SignUp.swift in Sources */,
+				D9A564E626BD696900ACB0EB /* User.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Vitamin/Vitamin.xcodeproj/project.pbxproj
+++ b/Vitamin/Vitamin.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1D990877E1EFB54A4F85E44E /* Pods_Vitamin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 79104825172E7C028AD3CDEA /* Pods_Vitamin.framework */; };
 		4DC0316826A42DDD00E929A4 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 4DC0316726A42DDD00E929A4 /* .swiftlint.yml */; };
 		D8D75DD365F598B2B294FEDA /* Pods_Vitamin_VitaminUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7471B47FDDF0403AE1956667 /* Pods_Vitamin_VitaminUITests.framework */; };
+		D9A564DF26BCCE3800ACB0EB /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A564DE26BCCE3800ACB0EB /* NetworkManager.swift */; };
 		D9C49EF8269A97E600A5FFA5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C49EF7269A97E600A5FFA5 /* AppDelegate.swift */; };
 		D9C49EFA269A97E600A5FFA5 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C49EF9269A97E600A5FFA5 /* SceneDelegate.swift */; };
 		D9C49EFC269A97E600A5FFA5 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C49EFB269A97E600A5FFA5 /* ViewController.swift */; };
@@ -49,6 +50,7 @@
 		7471B47FDDF0403AE1956667 /* Pods_Vitamin_VitaminUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Vitamin_VitaminUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		79104825172E7C028AD3CDEA /* Pods_Vitamin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Vitamin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C69DADE05C6ABDC668F8EF3B /* Pods-Vitamin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Vitamin.release.xcconfig"; path = "Target Support Files/Pods-Vitamin/Pods-Vitamin.release.xcconfig"; sourceTree = "<group>"; };
+		D9A564DE26BCCE3800ACB0EB /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		D9C49EF4269A97E600A5FFA5 /* Vitamin.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Vitamin.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9C49EF7269A97E600A5FFA5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D9C49EF9269A97E600A5FFA5 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -114,6 +116,7 @@
 		4DC030B9269AF75E00E929A4 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				D9A564DD26BCCE2900ACB0EB /* WebService */,
 				4DC030B8269AF71500E929A4 /* UIViewControllers */,
 			);
 			path = Sources;
@@ -148,6 +151,14 @@
 				6C1714BA967ADA82257E4E23 /* Pods-VitaminTests.release.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		D9A564DD26BCCE2900ACB0EB /* WebService */ = {
+			isa = PBXGroup;
+			children = (
+				D9A564DE26BCCE3800ACB0EB /* NetworkManager.swift */,
+			);
+			path = WebService;
 			sourceTree = "<group>";
 		};
 		D9C49EEB269A97E600A5FFA5 = {
@@ -460,6 +471,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9A564DF26BCCE3800ACB0EB /* NetworkManager.swift in Sources */,
 				D9C49EFC269A97E600A5FFA5 /* ViewController.swift in Sources */,
 				D9C49EF8269A97E600A5FFA5 /* AppDelegate.swift in Sources */,
 				D9C49EFA269A97E600A5FFA5 /* SceneDelegate.swift in Sources */,

--- a/Vitamin/Vitamin.xcodeproj/xcuserdata/innie.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Vitamin/Vitamin.xcodeproj/xcuserdata/innie.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>Vitamin.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>8</integer>
+			<integer>9</integer>
 		</dict>
 	</dict>
 </dict>

--- a/Vitamin/Vitamin.xcodeproj/xcuserdata/innie.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Vitamin/Vitamin.xcodeproj/xcuserdata/innie.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>Vitamin.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>9</integer>
+			<integer>8</integer>
 		</dict>
 	</dict>
 </dict>

--- a/Vitamin/Vitamin/Sources/Models/SignUp.swift
+++ b/Vitamin/Vitamin/Sources/Models/SignUp.swift
@@ -7,12 +7,12 @@
 
 import Foundation
 
-enum Gender: String, Encodable {
+enum Gender: String, Codable {
   case male = "남"
   case female = "여"
 }
 
-enum Age: Int, Encodable {
+enum Age: Int, Codable {
   case teen = 10
   case twenty = 20
   case thirty = 30

--- a/Vitamin/Vitamin/Sources/Models/SignUp.swift
+++ b/Vitamin/Vitamin/Sources/Models/SignUp.swift
@@ -1,0 +1,30 @@
+//
+//  SignUp.swift
+//  Vitamin
+//
+//  Created by 강인희 on 2021/08/06.
+//
+
+import Foundation
+
+enum Gender: String, Encodable {
+  case male = "남"
+  case female = "여"
+}
+
+enum Age: Int, Encodable {
+  case teen = 10
+  case twenty = 20
+  case thirty = 30
+  case fourty = 40
+  case fifty = 50
+  case elder = 60
+}
+
+struct SignUp: Encodable {
+  let email: String
+  let username: String
+  let age: Age
+  let gender: Gender
+  let password: String
+}

--- a/Vitamin/Vitamin/Sources/Models/User.swift
+++ b/Vitamin/Vitamin/Sources/Models/User.swift
@@ -6,3 +6,11 @@
 //
 
 import Foundation
+
+class User: Codable {
+  var email: String = ""
+  var username: String = ""
+  var gender: Gender
+  var age: Age
+  var password: String = ""
+}

--- a/Vitamin/Vitamin/Sources/Models/User.swift
+++ b/Vitamin/Vitamin/Sources/Models/User.swift
@@ -1,0 +1,8 @@
+//
+//  User.swift
+//  Vitamin
+//
+//  Created by 강인희 on 2021/08/06.
+//
+
+import Foundation

--- a/Vitamin/Vitamin/Sources/WebService/NetworkManager.swift
+++ b/Vitamin/Vitamin/Sources/WebService/NetworkManager.swift
@@ -11,7 +11,6 @@ import Alamofire
 class NetworkManager {
   static let shared = NetworkManager()
   private init() { }
-  
   func requestSignUp(with signUp: SignUp) {
     AF.request("https://63cce503-cc6a-4a4b-b954-040fc6ba31e3.mock.pstmn.io/auth/signup",
                method: .post,
@@ -22,12 +21,11 @@ class NetworkManager {
       .responseData(emptyResponseCodes: [200, 204, 205]) { response in
         switch response.result {
         case .success:
-          // User 모델 생성 과정 추가 필요
+          // return된 데이터 인코딩을 통한 User 모델 생성 과정 추가 필요
         case .failure(let error):
           // 회원가입 실패에 따른 처리 필요
-          debugPrint("회원가입 실패")
+          debugPrint("\(error) 로 인한 회원가입 실패")
         }
       }
   }
-  
 }

--- a/Vitamin/Vitamin/Sources/WebService/NetworkManager.swift
+++ b/Vitamin/Vitamin/Sources/WebService/NetworkManager.swift
@@ -11,21 +11,19 @@ import Alamofire
 class NetworkManager {
   static let shared = NetworkManager()
   private init() { }
-  func requestSignUp(with signUp: SignUp) {
-    AF.request("https://63cce503-cc6a-4a4b-b954-040fc6ba31e3.mock.pstmn.io/auth/signup",
-               method: .post,
-               parameters: signUp,
-               encoder: JSONParameterEncoder.default)
-      .validate(statusCode: 200..<300)
-      .validate(contentType: ["application/json"])
-      .responseData(emptyResponseCodes: [200, 204, 205]) { response in
-        switch response.result {
-        case .success:
-          // return된 데이터 인코딩을 통한 User 모델 생성 과정 추가 필요
-        case .failure(let error):
-          // 회원가입 실패에 따른 처리 필요
-          debugPrint("\(error) 로 인한 회원가입 실패")
-        }
+  func requestSignUp(with signUp: SignUp,
+                     completionHandler: @escaping (Result<User, Error>) -> Void) {
+    let signUpURL = URLMaker.makeRequestURL(feature: .signUp)
+    let request = AF.request(signUpURL,
+                             method: .post,
+                             parameters: signUp)
+    request.responseDecodable { (response: DataResponse<User, AFError>) in
+      switch response.result {
+      case .success(let user):
+        completionHandler(.success(user))
+      case .failure(let error):
+        completionHandler(.failure(error))
       }
+    }
   }
 }

--- a/Vitamin/Vitamin/Sources/WebService/NetworkManager.swift
+++ b/Vitamin/Vitamin/Sources/WebService/NetworkManager.swift
@@ -1,0 +1,33 @@
+//
+//  NetworkManager.swift
+//  Vitamin
+//
+//  Created by 강인희 on 2021/08/06.
+//
+
+import Foundation
+import Alamofire
+
+class NetworkManager {
+  static let shared = NetworkManager()
+  private init() { }
+  
+  func requestSignUp(with signUp: SignUp) {
+    AF.request("https://63cce503-cc6a-4a4b-b954-040fc6ba31e3.mock.pstmn.io/auth/signup",
+               method: .post,
+               parameters: signUp,
+               encoder: JSONParameterEncoder.default)
+      .validate(statusCode: 200..<300)
+      .validate(contentType: ["application/json"])
+      .responseData(emptyResponseCodes: [200, 204, 205]) { response in
+        switch response.result {
+        case .success:
+          // User 모델 생성 과정 추가 필요
+        case .failure(let error):
+          // 회원가입 실패에 따른 처리 필요
+          debugPrint("회원가입 실패")
+        }
+      }
+  }
+  
+}

--- a/Vitamin/Vitamin/Sources/WebService/URLMaker.swift
+++ b/Vitamin/Vitamin/Sources/WebService/URLMaker.swift
@@ -6,3 +6,21 @@
 //
 
 import Foundation
+import Alamofire
+
+enum Feature {
+  case signUp
+  var urlPath: String {
+    switch self {
+    case .signUp:
+      return "/auth/signup"
+    }
+  }
+}
+
+struct URLMaker {
+  static let baseURL = "https://63cce503-cc6a-4a4b-b954-040fc6ba31e3.mock.pstmn.io/"
+  static func makeRequestURL(feature: Feature) -> String {
+    return "\(self.baseURL)\(feature.urlPath)"
+  }
+}

--- a/Vitamin/Vitamin/Sources/WebService/URLMaker.swift
+++ b/Vitamin/Vitamin/Sources/WebService/URLMaker.swift
@@ -1,0 +1,8 @@
+//
+//  URLMaker.swift
+//  Vitamin
+//
+//  Created by 강인희 on 2021/08/06.
+//
+
+import Foundation


### PR DESCRIPTION
진향님 안녕하세요! @TheSongOfSongs 
회원가입 요청 과정 구현에 대한 PR입니다.

- 주요 구현 사항
1. WebService 디렉토리 내의 NetworkManager
    - 앱 전역에서 AlamoFire 의 네트워크 호출 메소드를 활용하여 네트워크 통신을 담당하는 객체로 Singleton 으로 구현했습니다.<br>
    
1. Models 디렉토리 내의 SignUp
    - 백엔드 API문서에서 회원가입 시 요구하는 사항들을 모아놓은 Struct타입으로 회원가입 시 활용합니다.
    - 네트워크 요청 시 인코딩 과정이 필요하여 Encodable 프로토콜을 채택합니다.
    - 부가적으로 필요한 Gender 및 Age 에 대해 Enum 타입으로 구현했습니다.<br>
    
1. NetworkManager의 requestSignUp 메소드
    - 백엔드 서버로의 회원가입 요청(POST) 과정을 구현하였습니다.
    - 요청 결과에 따른 success 와 fail 에 대한 처리 과정에 대한 구현을 부탁드립니다. 해당 부분에 주석으로 작성해놨습니다. (User생성 / error에 대한 처리) 