### PR TITLE
Extension, UserDefaultsHelper 파일 추가

### DIFF
--- a/Vitamin/Vitamin.xcodeproj/project.pbxproj
+++ b/Vitamin/Vitamin.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1D990877E1EFB54A4F85E44E /* Pods_Vitamin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 79104825172E7C028AD3CDEA /* Pods_Vitamin.framework */; };
 		4D27530626BD57290097B8EB /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D27530526BD57290097B8EB /* Constants.swift */; };
 		4D27530E26BD6CB40097B8EB /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D27530D26BD6CB40097B8EB /* UIViewController+Extension.swift */; };
+		4D27538326BD969C0097B8EB /* UserDefaultsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D27538226BD969C0097B8EB /* UserDefaultsHelper.swift */; };
 		4DBD90F726BD54F6005FA999 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBD90F626BD54F6005FA999 /* UIView+Extension.swift */; };
 		4DBD90FD26BD5531005FA999 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBD90FC26BD5531005FA999 /* Font.swift */; };
 		4DBD910226BD555D005FA999 /* UIDevice+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBD910126BD555D005FA999 /* UIDevice+Extension.swift */; };
@@ -56,6 +57,7 @@
 		2EA85F98757D77AA70A28170 /* Pods_VitaminTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VitaminTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4D27530526BD57290097B8EB /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		4D27530D26BD6CB40097B8EB /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
+		4D27538226BD969C0097B8EB /* UserDefaultsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsHelper.swift; sourceTree = "<group>"; };
 		4DBD90F626BD54F6005FA999 /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
 		4DBD90FC26BD5531005FA999 /* Font.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Font.swift; sourceTree = "<group>"; };
 		4DBD910126BD555D005FA999 /* UIDevice+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+Extension.swift"; sourceTree = "<group>"; };
@@ -123,6 +125,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		4D27538126BD968E0097B8EB /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				4D27538226BD969C0097B8EB /* UserDefaultsHelper.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
 		4DBD90F526BD54C9005FA999 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -158,6 +168,7 @@
 				4DC030B8269AF71500E929A4 /* UIViewControllers */,
 				4DBD90FB26BD5527005FA999 /* Enums */,
 				4DBD90F526BD54C9005FA999 /* Extensions */,
+				4D27538126BD968E0097B8EB /* Helpers */,
 				4D27530526BD57290097B8EB /* Constants.swift */,
 			);
 			path = Sources;
@@ -522,6 +533,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4D27538326BD969C0097B8EB /* UserDefaultsHelper.swift in Sources */,
 				D9A564E426BD647100ACB0EB /* URLMaker.swift in Sources */,
 				D9A564DF26BCCE3800ACB0EB /* NetworkManager.swift in Sources */,
 				4D27530E26BD6CB40097B8EB /* UIViewController+Extension.swift in Sources */,

--- a/Vitamin/Vitamin.xcodeproj/project.pbxproj
+++ b/Vitamin/Vitamin.xcodeproj/project.pbxproj
@@ -9,6 +9,12 @@
 /* Begin PBXBuildFile section */
 		1801189CF5CB8783E08CFF32 /* Pods_VitaminTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2EA85F98757D77AA70A28170 /* Pods_VitaminTests.framework */; };
 		1D990877E1EFB54A4F85E44E /* Pods_Vitamin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 79104825172E7C028AD3CDEA /* Pods_Vitamin.framework */; };
+		4D27530626BD57290097B8EB /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D27530526BD57290097B8EB /* Constants.swift */; };
+		4D27530E26BD6CB40097B8EB /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D27530D26BD6CB40097B8EB /* UIViewController+Extension.swift */; };
+		4DBD90F726BD54F6005FA999 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBD90F626BD54F6005FA999 /* UIView+Extension.swift */; };
+		4DBD90FD26BD5531005FA999 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBD90FC26BD5531005FA999 /* Font.swift */; };
+		4DBD910226BD555D005FA999 /* UIDevice+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBD910126BD555D005FA999 /* UIDevice+Extension.swift */; };
+		4DBD910726BD55B7005FA999 /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBD910626BD55B7005FA999 /* UIFont+Extension.swift */; };
 		4DC0316826A42DDD00E929A4 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 4DC0316726A42DDD00E929A4 /* .swiftlint.yml */; };
 		D8D75DD365F598B2B294FEDA /* Pods_Vitamin_VitaminUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7471B47FDDF0403AE1956667 /* Pods_Vitamin_VitaminUITests.framework */; };
 		D9A564DF26BCCE3800ACB0EB /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A564DE26BCCE3800ACB0EB /* NetworkManager.swift */; };
@@ -48,6 +54,12 @@
 		214495BA2DE23CAE316FEB42 /* Pods-Vitamin-VitaminUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Vitamin-VitaminUITests.release.xcconfig"; path = "Target Support Files/Pods-Vitamin-VitaminUITests/Pods-Vitamin-VitaminUITests.release.xcconfig"; sourceTree = "<group>"; };
 		2D17F98A158CE7407933F864 /* Pods-Vitamin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Vitamin.debug.xcconfig"; path = "Target Support Files/Pods-Vitamin/Pods-Vitamin.debug.xcconfig"; sourceTree = "<group>"; };
 		2EA85F98757D77AA70A28170 /* Pods_VitaminTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VitaminTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4D27530526BD57290097B8EB /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		4D27530D26BD6CB40097B8EB /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
+		4DBD90F626BD54F6005FA999 /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
+		4DBD90FC26BD5531005FA999 /* Font.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Font.swift; sourceTree = "<group>"; };
+		4DBD910126BD555D005FA999 /* UIDevice+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+Extension.swift"; sourceTree = "<group>"; };
+		4DBD910626BD55B7005FA999 /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 		4DC0316726A42DDD00E929A4 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		6C1714BA967ADA82257E4E23 /* Pods-VitaminTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VitaminTests.release.xcconfig"; path = "Target Support Files/Pods-VitaminTests/Pods-VitaminTests.release.xcconfig"; sourceTree = "<group>"; };
 		7471B47FDDF0403AE1956667 /* Pods_Vitamin_VitaminUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Vitamin_VitaminUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -111,6 +123,25 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		4DBD90F526BD54C9005FA999 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				4DBD90F626BD54F6005FA999 /* UIView+Extension.swift */,
+				4DBD910126BD555D005FA999 /* UIDevice+Extension.swift */,
+				4DBD910626BD55B7005FA999 /* UIFont+Extension.swift */,
+				4D27530D26BD6CB40097B8EB /* UIViewController+Extension.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		4DBD90FB26BD5527005FA999 /* Enums */ = {
+			isa = PBXGroup;
+			children = (
+				4DBD90FC26BD5531005FA999 /* Font.swift */,
+			);
+			path = Enums;
+			sourceTree = "<group>";
+		};
 		4DC030B8269AF71500E929A4 /* UIViewControllers */ = {
 			isa = PBXGroup;
 			children = (
@@ -125,6 +156,9 @@
 				D9A564E026BCCF1500ACB0EB /* Models */,
 				D9A564DD26BCCE2900ACB0EB /* WebService */,
 				4DC030B8269AF71500E929A4 /* UIViewControllers */,
+				4DBD90FB26BD5527005FA999 /* Enums */,
+				4DBD90F526BD54C9005FA999 /* Extensions */,
+				4D27530526BD57290097B8EB /* Constants.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -401,7 +435,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\n${PODS_ROOT}/SwiftLint/swiftlint\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\n${PODS_ROOT}/SwiftLint/swiftlint autocorrect\n";
 		};
 		6736F1F4871E968010185875 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -490,11 +524,17 @@
 			files = (
 				D9A564E426BD647100ACB0EB /* URLMaker.swift in Sources */,
 				D9A564DF26BCCE3800ACB0EB /* NetworkManager.swift in Sources */,
+				4D27530E26BD6CB40097B8EB /* UIViewController+Extension.swift in Sources */,
+				4DBD910726BD55B7005FA999 /* UIFont+Extension.swift in Sources */,
 				D9C49EFC269A97E600A5FFA5 /* ViewController.swift in Sources */,
+				4DBD910226BD555D005FA999 /* UIDevice+Extension.swift in Sources */,
 				D9C49EF8269A97E600A5FFA5 /* AppDelegate.swift in Sources */,
+				4DBD90FD26BD5531005FA999 /* Font.swift in Sources */,
+				4DBD90F726BD54F6005FA999 /* UIView+Extension.swift in Sources */,
 				D9C49EFA269A97E600A5FFA5 /* SceneDelegate.swift in Sources */,
 				D9A564E226BCCF2100ACB0EB /* SignUp.swift in Sources */,
 				D9A564E626BD696900ACB0EB /* User.swift in Sources */,
+				4D27530626BD57290097B8EB /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Vitamin/Vitamin/Sources/Constants.swift
+++ b/Vitamin/Vitamin/Sources/Constants.swift
@@ -1,0 +1,15 @@
+//
+//  Constants.swift
+//  Vitamin
+//
+//  Created by Jinhyang on 2021/08/06.
+//
+
+import Foundation
+
+enum Constants {
+  enum Locale: String {
+    case english = "en"
+    case korean = "ko"
+  }
+}

--- a/Vitamin/Vitamin/Sources/Enums/Font.swift
+++ b/Vitamin/Vitamin/Sources/Enums/Font.swift
@@ -1,0 +1,266 @@
+//
+//  Font.swift
+//
+//  Created by Aaron Lee on 2021/06/22.
+//
+
+import UIKit
+
+/// 폰트 타입
+private enum FontType: String {
+  case bold = "Bold"
+  case regular = "Regular"
+  case medium = "Medium"
+}
+
+enum Font: CaseIterable {
+  /// 22 regular
+  case title1
+  /// 22 medium
+  case title2
+
+  /// 22 bold
+  case title3
+
+  /// 24 regular
+  case title4
+
+  /// 24 medium
+  case title5
+
+  /// 24 bold
+  case title6
+
+  /// 타이틀 전체
+  static var titles: [Font] {
+    return [.title1,
+            .title2,
+            .title3,
+            .title4,
+            .title5,
+            .title6]
+  }
+
+  /// 18 regular
+  case subtitle1
+
+  /// 18 medium
+  case subtitle2
+
+  /// 18 bold
+  case subtitle3
+
+  /// 20 regular
+  case subtitle4
+
+  /// 20 medium
+  case subtitle5
+
+  /// 20 bold
+  case subtitle6
+
+  /// Subtitle 전체
+  static var subtitles: [Font] {
+    return [.subtitle1,
+            .subtitle2,
+            .subtitle3,
+            .subtitle4,
+            .subtitle5,
+            .subtitle6]
+  }
+
+  /// 16 regular
+  case body1
+
+  /// 16 medium
+  case body2
+
+  /// 16 bold
+  case body3
+
+  /// 14 regular
+  case body4
+
+  /// 14 medium
+  case body5
+
+  /// 14 bold
+  case body6
+
+  /// Body 전체
+  static var bodies: [Font] {
+    return [.body1,
+            .body2,
+            .body3,
+            .body4,
+            .body5,
+            .body6]
+  }
+
+  /// 12 regular
+  case context1
+
+  /// 12 medium
+  case context2
+
+  /// 12 bold
+  case context3
+
+  /// 10 regular
+  case context4
+
+  /// 10 medium
+  case context5
+
+  /// 10 bold
+  case context6
+
+  /// Context 전체
+  static var contexts: [Font] {
+    return [.context1,
+            .context2,
+            .context3,
+            .context4,
+            .context5,
+            .context6]
+  }
+
+  /// 34 regular
+  case headline1
+  /// 34 medium
+  case headline2
+  /// 34 bold
+  case headline3
+
+  /// Headline 전체
+  static var headlines: [Font] {
+    return [
+      .headline1,
+      .headline2,
+      .headline3]
+  }
+
+}
+
+extension Font {
+
+  /// 언어 코드
+  ///
+  /// https://developer.apple.com/documentation/foundation/nslocale
+  ///
+  /// https://gist.github.com/jacobbubu/1836273
+  private func languageCode() -> Constants.Locale? {
+    let localeStr = String(UIDevice.currentLocale.prefix(2))
+    return Constants.Locale(rawValue: localeStr)
+  }
+
+  /// 폰트 파일 명
+  private func localizedFontName() -> String {
+    let defaultFont = "SpoqaHanSansNeo-"
+
+    let code = languageCode()
+
+    switch code {
+    case .english, .korean: return defaultFont
+    default: return defaultFont
+    }
+
+  }
+
+  var font: UIFont? {
+
+    let fontType: FontType
+    var fontSize: CGFloat
+
+    switch self {
+    case .title1:
+      fontType = .regular
+      fontSize = 22
+    case .title2:
+      fontType = .medium
+      fontSize = 22
+    case .title3:
+      fontType = .bold
+      fontSize = 22
+    case .title4:
+      fontType = .regular
+      fontSize = 24
+    case .title5:
+      fontType = .medium
+      fontSize = 24
+    case .title6:
+      fontType = .bold
+      fontSize = 24
+    case .subtitle1:
+      fontType = .regular
+      fontSize = 18
+    case .subtitle2:
+      fontType = .medium
+      fontSize = 18
+    case .subtitle3:
+      fontType = .bold
+      fontSize = 18
+    case .subtitle4:
+      fontType = .regular
+      fontSize = 20
+    case .subtitle5:
+      fontType = .medium
+      fontSize = 20
+    case .subtitle6:
+      fontType = .bold
+      fontSize = 20
+    case .body1:
+      fontType = .regular
+      fontSize = 16
+    case .body2:
+      fontType = .medium
+      fontSize = 16
+    case .body3:
+      fontType = .bold
+      fontSize = 16
+    case .body4:
+      fontType = .regular
+      fontSize = 14
+    case .body5:
+      fontType = .medium
+      fontSize = 14
+    case .body6:
+      fontType = .bold
+      fontSize = 14
+    case .context1:
+      fontType = .regular
+      fontSize = 12
+    case .context2:
+      fontType = .medium
+      fontSize = 12
+    case .context3:
+      fontType = .bold
+      fontSize = 12
+    case .context4:
+      fontType = .regular
+      fontSize = 10
+    case .context5:
+      fontType = .medium
+      fontSize = 10
+    case .context6:
+      fontType = .bold
+      fontSize = 10
+    case .headline1:
+      fontType = .regular
+      fontSize = 34
+    case .headline2:
+      fontType = .medium
+      fontSize = 34
+    case .headline3:
+      fontType = .bold
+      fontSize = 34
+    }
+
+    if !Font.contexts.contains(self) && UIDevice.isSmallDevice {
+      fontSize -= 1
+    }
+
+    return UIFont(name: "\(localizedFontName())\(fontType.rawValue)",
+                  size: fontSize)
+  }
+}

--- a/Vitamin/Vitamin/Sources/Extensions/UIDevice+Extension.swift
+++ b/Vitamin/Vitamin/Sources/Extensions/UIDevice+Extension.swift
@@ -1,0 +1,31 @@
+//
+//  UIDevice+Ext.swift
+//
+//  Created by Aaron Lee on 2021/08/06.
+//
+
+import UIKit
+
+extension UIDevice {
+
+  static let currentLocale = Locale.preferredLanguages[0]
+
+  var modelName: String {
+    var systemInfo = utsname()
+    uname(&systemInfo)
+    let machineMirror = Mirror(reflecting: systemInfo.machine)
+    let identifier = machineMirror.children.reduce("") { identifier, element in
+      guard let value = element.value as? Int8, value != 0 else { return identifier }
+      return identifier + String(UnicodeScalar(UInt8(value)))
+    }
+    return identifier
+  }
+
+  // Checks if device is an iPhone 5s, iPhone SE, or iPod Touch 6th gen
+  static var isSmallDevice: Bool {
+    return UIDevice.current.modelName == "iPhone6,1"
+      || UIDevice.current.modelName == "iPhone6,2"
+      || UIDevice.current.modelName == "iPod7,1"
+      || UIDevice.current.modelName == "iPhone8,4"
+  }
+}

--- a/Vitamin/Vitamin/Sources/Extensions/UIFont+Extension.swift
+++ b/Vitamin/Vitamin/Sources/Extensions/UIFont+Extension.swift
@@ -1,0 +1,15 @@
+//
+//  UIFont+Ext.swift
+//
+//  Created by Aaron Lee on 2021/05/21.
+//
+import UIKit
+
+extension UIFont {
+
+    /// 폰트
+    class func font(_ font: Font) -> UIFont? {
+        return font.font
+    }
+
+}

--- a/Vitamin/Vitamin/Sources/Extensions/UIView+Extension.swift
+++ b/Vitamin/Vitamin/Sources/Extensions/UIView+Extension.swift
@@ -1,0 +1,37 @@
+//
+//  UIView+Ext.swift
+//
+//  Created by Aaron Lee on 2021/05/18.
+//
+import UIKit
+
+extension UIView {
+
+  class var identifier: String {
+      return String(describing: self)
+  }
+
+  func makeRounded(radius: CGFloat, at corners: CACornerMask = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]) {
+      self.layer.cornerRadius = radius
+      self.clipsToBounds = true
+
+      self.layer.maskedCorners = corners
+  }
+
+  /// 폰트 적용
+  func font(_ font: Font) {
+    if let button = self as? UIButton {
+      button.titleLabel?.font = .font(font)
+    } else if let label = self as? UILabel {
+      label.font = .font(font)
+    } else if let textField  = self as? UITextField {
+      textField.font = .font(font)
+    } else if let textView = self as? UITextView {
+      textView.font = .font(font)
+    } else {
+      for subview in subviews {
+        subview.font(font)
+      }
+    }
+  }
+}

--- a/Vitamin/Vitamin/Sources/Extensions/UIViewController+Extension.swift
+++ b/Vitamin/Vitamin/Sources/Extensions/UIViewController+Extension.swift
@@ -1,0 +1,14 @@
+//
+//  UIViewController+Extension.swift
+//  Vitamin
+//
+//  Created by Jinhyang on 2021/08/06.
+//
+
+import UIKit
+
+extension UIViewController {
+    class var identifier: String {
+        return String(describing: self)
+    }
+}

--- a/Vitamin/Vitamin/Sources/Helpers/UserDefaultsHelper.swift
+++ b/Vitamin/Vitamin/Sources/Helpers/UserDefaultsHelper.swift
@@ -1,0 +1,31 @@
+//
+//  UserDefaultsHelper.swift
+//  Vitamin
+//
+//  Created by Jinhyang on 2021/08/07.
+//
+
+import UIKit
+
+final class UserDefaultsHelper {
+    static func setData<T>(value: T, key: UserDefaultKeys) {
+        let defaults = UserDefaults.standard
+        defaults.set(value, forKey: key.rawValue)
+    }
+
+    static func getData<T>(type: T.Type, forKey: UserDefaultKeys) -> T? {
+        let defaults = UserDefaults.standard
+        let value = defaults.object(forKey: forKey.rawValue) as? T
+
+        return value
+    }
+
+    static func removeData(key: UserDefaultKeys) {
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: key.rawValue)
+    }
+}
+
+enum UserDefaultKeys: String, CaseIterable {
+  case a // 가데이터
+}

--- a/Vitamin/Vitamin/Sources/UIViewControllers/ViewController.swift
+++ b/Vitamin/Vitamin/Sources/UIViewControllers/ViewController.swift
@@ -8,10 +8,10 @@
 import UIKit
 
 class ViewController: UIViewController {
-  
+
   override func viewDidLoad() {
     super.viewDidLoad()
     // Do any additional setup after loading the view.
   }
-  
+
 }


### PR DESCRIPTION
1. Extension 파일 추가

- UIViewController, UIView의 identifier
    - UIView나 UIViewController 생성 시, storyboard의 ID와 클래스 이름을 같게 하면 사용하기 편합니다.
    - instantiateViewController 메소드를 사용할 때 identifier로 쉽게 스토리보드를 사용하면 됩니다.
`if let loginVC = self.storyboard?.instantiateViewController(withIdentifier: LoginViewController.identifier) as? LoginViewController { }`

- UIView의 makeRounded(radius:at corners)
    - radius 값에 원하는 만큼의 값을 넣고 corners에는 원하는 모서리를 넣어줍니다. argument에 기본값이 할당되어 있어, 값을 전달하지 않으면 네 모서리 모두 둥글게 나옵니다.
    - 온보딩 구현 시 참고하면 좋을 것 같습니다.

- slack에 올라온 Extension 파일들을 추가했습니다.
 
<br/>
<br/>

2. UserDefaultsHelper 파일 추가
- enum 타입인 UserDefaultKeys에 원하는 key 값을 추가해줍니다.
- generic 타입으로 class를 구현하여, setData, getData 시 원하는 타입도 함께 보내줘야 합니다.
- 값이 없으면 nil을 반환합니다.